### PR TITLE
[Bugfix] past_key_values is tuple when num_beams>1

### DIFF
--- a/models/modeling_nanbeige.py
+++ b/models/modeling_nanbeige.py
@@ -550,7 +550,7 @@ class NanbeigeModel(NanbeigePreTrainedModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
-            past_key_value = past_key_values.pop(0) if past_key_values is not None else None
+            past_key_value = past_key_values[idx] if past_key_values is not None else None
 
             if self.gradient_checkpointing and self.training:
 


### PR DESCRIPTION
past_key_values is tuple when num_beams>1, it'll have no the method pop().